### PR TITLE
fix: linux mount

### DIFF
--- a/packages/backend/src/managers/instructlab/instructlabManager.ts
+++ b/packages/backend/src/managers/instructlab/instructlabManager.ts
@@ -205,17 +205,17 @@ export class InstructlabManager {
         AutoRemove: true,
         Mounts: [
           {
-            Target: '/instructlab/.cache/instructlab',
+            Target: '/instructlab/.cache/instructlab:Z',
             Source: path.join(folder, '.cache'),
             Type: 'bind',
           },
           {
-            Target: '/instructlab/.config/instructlab',
+            Target: '/instructlab/.config/instructlab:Z',
             Source: path.join(folder, '.config'),
             Type: 'bind',
           },
           {
-            Target: '/instructlab/.local/share/instructlab',
+            Target: '/instructlab/.local/share/instructlab:Z',
             Source: path.join(folder, '.local'),
             Type: 'bind',
           },


### PR DESCRIPTION
Tested on linux, adding :Z flag allowed me to run `ilab config init` on podman native

![image](https://github.com/user-attachments/assets/d56554ac-5cf8-47e6-97c5-298014b76726)
